### PR TITLE
Feat/update comment

### DIFF
--- a/gitlab-comment.yaml
+++ b/gitlab-comment.yaml
@@ -5,7 +5,7 @@ post:
   hello:
     # update: 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"'
     template: |
-      $Hello: foo {{ "hello!" | upper | repeat 5 }}
+      $Hello: foo {{ "hello!" | upper | repeat 5 }} {{Env "HELLO"}}
 
 exec:
   hello:

--- a/gitlab-comment.yaml
+++ b/gitlab-comment.yaml
@@ -10,6 +10,7 @@ post:
 exec:
   hello:
     - when: ExitCode != 0
+      # update: 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"'
       template: |
         failure
         exit code: {{.ExitCode}}
@@ -17,6 +18,7 @@ exec:
         stderr: {{.Stderr}}
         combined output: {{.CombinedOutput}}
     - when: true
+      # update: 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"'
       template: |
         exit code: {{.ExitCode}}
         stdout: {{.Stdout}}

--- a/pkg/api/post_internal_test.go
+++ b/pkg/api/post_internal_test.go
@@ -46,7 +46,7 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				Org:      "yuyaban",
 				Repo:     "gitlab-comment",
 				MRNumber: 1,
-				Vars:     map[string]interface{}{},
+				Vars:     map[string]interface{}{"target": ""},
 			},
 		},
 		{
@@ -75,7 +75,7 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				Org:      "yuyaban",
 				Repo:     "gitlab-comment",
 				MRNumber: 1,
-				Vars:     map[string]interface{}{},
+				Vars:     map[string]interface{}{"target": ""},
 			},
 		},
 		{
@@ -114,7 +114,7 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				Repo:        "gitlab-comment",
 				MRNumber:    1,
 				TemplateKey: "default",
-				Vars:        map[string]interface{}{},
+				Vars:        map[string]interface{}{"target": ""},
 			},
 		},
 		{
@@ -149,7 +149,7 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				Org:      "yuyaban",
 				Repo:     "gitlab-comment",
 				MRNumber: 1,
-				Vars:     map[string]interface{}{},
+				Vars:     map[string]interface{}{"target": ""},
 			},
 		},
 		{
@@ -181,7 +181,7 @@ func TestPostController_getCommentParams(t *testing.T) { //nolint:funlen
 				Org:      "yuyaban",
 				Repo:     "gitlab-comment",
 				MRNumber: 1,
-				Vars:     map[string]interface{}{},
+				Vars:     map[string]interface{}{"target": ""},
 			},
 		},
 	}

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -167,6 +167,11 @@ func (runner *Runner) Run(ctx context.Context, args []string) error { //nolint:f
 						Aliases: []string{"s"},
 						Usage:   "suppress the output of dry-run and skip-no-token",
 					},
+					&cli.StringFlag{
+						Name:    "update-condition",
+						Aliases: []string{"u"},
+						Usage:   "update the comment that matches with the condition",
+					},
 				},
 			},
 			{

--- a/pkg/cmd/exec.go
+++ b/pkg/cmd/exec.go
@@ -28,6 +28,7 @@ func parseExecOptions(opts *option.ExecOptions, c *cli.Context) error {
 	opts.DryRun = c.Bool("dry-run")
 	opts.SkipNoToken = c.Bool("skip-no-token")
 	opts.Silent = c.Bool("silent")
+	opts.UpdateCondition = c.String("update-condition")
 	opts.LogLevel = c.String("log-level")
 
 	vars, err := parseVarsFlag(c.StringSlice("var"))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -92,6 +92,7 @@ type ExecConfig struct {
 	TemplateForTooLong string   `yaml:"template_for_too_long"`
 	DontComment        bool     `yaml:"dont_comment"`
 	EmbeddedVarNames   []string `yaml:"embedded_var_names"`
+	UpdateCondition    string   `yaml:"update"`
 }
 
 type ExistFile func(string) bool

--- a/pkg/gitlab/note.go
+++ b/pkg/gitlab/note.go
@@ -11,7 +11,6 @@ type Note struct {
 	MRNumber       int
 	Org            string
 	Repo           string
-	NoteID         int
 	Body           string
 	BodyForTooLong string
 	SHA1           string
@@ -21,11 +20,11 @@ type Note struct {
 }
 
 func (client *Client) sendMRComment(note *Note, body string) error {
-	if note.NoteID != 0 {
+	if note.ID != 0 {
 		if _, _, err := client.note.UpdateMergeRequestNote(
 			fmt.Sprintf("%s/%s", note.Org, note.Repo),
 			note.MRNumber,
-			note.NoteID,
+			note.ID,
 			&gitlab.UpdateMergeRequestNoteOptions{Body: gitlab.String(body)},
 		); err != nil {
 			return fmt.Errorf("edit a merge request note by Gitlab API: %w", err)

--- a/pkg/option/exec.go
+++ b/pkg/option/exec.go
@@ -4,8 +4,9 @@ import "errors"
 
 type ExecOptions struct {
 	Options
-	Args        []string
-	SkipComment bool
+	Args            []string
+	SkipComment     bool
+	UpdateCondition string
 }
 
 func ValidateExec(opts *ExecOptions) error {


### PR DESCRIPTION
## Description
Two functions have been added.
* When UpdateCondition is in effect in the post function, a special variable called target is added to the metadata to identify the comment to be updated.
  * When using the same template for several different jobs, the target variable can be used to avoid duplicate comments to be updated.
* Add UpdateCondition to the exec function as well, similar to post

## Test Case
### Post
```
$ HELLO=test1 go run ./cmd/gitlab-comment post --org yuyaban --repo gitlab-comment --mr 1 -k hello -u 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"' --var target:"JOB_A"
$ HELLO=test2 go run ./cmd/gitlab-comment post --org yuyaban --repo gitlab-comment --mr 1 -k hello -u 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"' --var target:"JOB_A"
$ HELLO=test1 go run ./cmd/gitlab-comment post --org yuyaban --repo gitlab-comment --mr 1 -k hello -u 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"' --var target:"JOB_B"
```
## Exec
```
$ go run ./cmd/gitlab-comment exec --org yuyaban --repo gitlab-comment --mr 1 -k hello -u 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"' --var target:"JOB_A" -- echo "test comment test1" 
$ go run ./cmd/gitlab-comment exec --org yuyaban --repo gitlab-comment --mr 1 -k hello -u 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"' --var target:"JOB_A" -- echo "test comment test2"
$ go run ./cmd/gitlab-comment exec --org yuyaban --repo gitlab-comment --mr 1 -k hello -u 'Comment.HasMeta && Comment.Meta.TemplateKey == "hello"' --var target:"JOB_B" -- echo "test comment test1"
```

