### PR TITLE
Retrieve mr number from commit hash

### DIFF
--- a/pkg/gitlab/client.go
+++ b/pkg/gitlab/client.go
@@ -9,7 +9,7 @@ import (
 
 type Client struct {
 	note NoteServices
-	mr   MergeRewuestsService
+	mr   MergeRequestsService
 }
 
 type ParamNew struct {
@@ -59,4 +59,4 @@ type NoteServices interface {
 	UpdateMergeRequestNote(pid interface{}, mergeRequest, note int, opt *gitlab.UpdateMergeRequestNoteOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Note, *gitlab.Response, error)
 	ListMergeRequestNotes(pid interface{}, mergeRequest int, opt *gitlab.ListMergeRequestNotesOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Note, *gitlab.Response, error)
 }
-type MergeRewuestsService interface{}
+type MergeRequestsService interface{}

--- a/pkg/gitlab/client.go
+++ b/pkg/gitlab/client.go
@@ -8,8 +8,9 @@ import (
 )
 
 type Client struct {
-	note NoteServices
-	mr   MergeRequestsService
+	note   NoteServices
+	mr     MergeRequestsService
+	commit CommitService
 }
 
 type ParamNew struct {
@@ -38,6 +39,7 @@ func New(param *ParamNew) (*Client, error) {
 
 	client.note = gl.Notes
 	client.mr = gl.MergeRequests
+	client.commit = gl.Commits
 
 	return client, nil
 }
@@ -59,4 +61,9 @@ type NoteServices interface {
 	UpdateMergeRequestNote(pid interface{}, mergeRequest, note int, opt *gitlab.UpdateMergeRequestNoteOptions, options ...gitlab.RequestOptionFunc) (*gitlab.Note, *gitlab.Response, error)
 	ListMergeRequestNotes(pid interface{}, mergeRequest int, opt *gitlab.ListMergeRequestNotesOptions, options ...gitlab.RequestOptionFunc) ([]*gitlab.Note, *gitlab.Response, error)
 }
+
 type MergeRequestsService interface{}
+
+type CommitService interface {
+	ListMergeRequestsByCommit(pid interface{}, sha string, options ...gitlab.RequestOptionFunc) ([]*gitlab.MergeRequest, *gitlab.Response, error)
+}

--- a/pkg/gitlab/mr.go
+++ b/pkg/gitlab/mr.go
@@ -5,19 +5,17 @@ import (
 )
 
 func (client *Client) MRNumberWithSHA(owner, repo, sha string) (int, error) {
-	return 0, fmt.Errorf("not yet Supported MRNumberWithSHA method")
-	// prs, _, err := client.mr.ListMergeRequestsWithCommit(ctx, owner, repo, sha, &gitlab.MergeRequestListOptions{
-	// 	State: "all",
-	// 	Sort:  "updated",
-	// 	ListOptions: gitlab.ListOptions{
-	// 		PerPage: 1,
-	// 	},
-	// })
-	// if err != nil {
-	// 	return 0, fmt.Errorf("list associated merge requests: %w", err)
-	// }
-	// if len(prs) == 0 {
-	// 	return 0, errors.New("associated merge request isn't found")
-	// }
-	// return prs[0].GetNumber(), nil
+	mrList, _, err := client.commit.ListMergeRequestsByCommit(
+		fmt.Sprintf("%s/%s", owner, repo),
+		sha,
+	)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(mrList) == 0 {
+		return 0, fmt.Errorf("sha is not associated with MR")
+	}
+
+	return mrList[0].IID, nil
 }

--- a/pkg/gitlab/mr.go
+++ b/pkg/gitlab/mr.go
@@ -10,7 +10,7 @@ func (client *Client) MRNumberWithSHA(owner, repo, sha string) (int, error) {
 		sha,
 	)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("list associated pull requests: %w", err)
 	}
 
 	if len(mrList) == 0 {

--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -42,7 +42,7 @@ func (pt *Platform) getMRNumber() (int, error) {
 		}
 		return a, nil
 	}
-	return 0, fmt.Errorf("parse CI_MERGE_REQUEST_IID")
+	return 0, nil
 }
 
 func (pt *Platform) complement(opts *option.Options) error {


### PR DESCRIPTION
Hi @yuyaban . Thank you for the nice tool!

I want to comment to MR when the MR is merged. So, I implemented the feature to retrieve MR number associated with SHA1.

And, sorry:pray: This PR include #9 commits. :bow: :bow:
So, I will close #9