### PR TITLE
make possible to update comment even when using `--stdin-template`

### DIFF
--- a/pkg/api/post.go
+++ b/pkg/api/post.go
@@ -197,12 +197,13 @@ func (ctrl *PostController) getCommentParams(opts *option.PostOptions) (*gitlab.
 		opts.Template = tpl.Template
 		opts.TemplateForTooLong = tpl.TemplateForTooLong
 		opts.EmbeddedVarNames = tpl.EmbeddedVarNames
-		if !contains(opts.EmbeddedVarNames, "target") {
-			opts.EmbeddedVarNames = append(opts.EmbeddedVarNames, "target")
-		}
 		if opts.UpdateCondition == "" {
 			opts.UpdateCondition = tpl.UpdateCondition
 		}
+	}
+
+	if !contains(opts.EmbeddedVarNames, "target") {
+		opts.EmbeddedVarNames = append(opts.EmbeddedVarNames, "target")
 	}
 
 	if cfg.Vars == nil {


### PR DESCRIPTION
Thank you for making this project available to the public.

Currently, when using `--stdin-template`, the `target` variable is not used and existing comments cannot be updated.

This pull request will add `target` to `EmbededVarNames` to allow comments to be updated even when `--stdin-template` is used.